### PR TITLE
Limit memory usage when large files are streamed

### DIFF
--- a/examples/sveltekit-file-uploads-nodejs/src/routes/files/[name]/+server.js
+++ b/examples/sveltekit-file-uploads-nodejs/src/routes/files/[name]/+server.js
@@ -31,7 +31,11 @@ export async function GET({ params, request }) {
 	};
 
 	const nodejs_rstream = fs.createReadStream(file_path);
-	const web_rstream = Readable.toWeb(nodejs_rstream);
+
+	const web_rstream = Readable.toWeb(nodejs_rstream, {
+		// See: https://github.com/nodejs/node/issues/46347#issuecomment-1416310527
+		strategy: new CountQueuingStrategy({ highWaterMark: 100 })
+	});
 
 	return new Response(web_rstream, { headers });
 }


### PR DESCRIPTION
This PR limits the memory usage when large files are streamed as discussed in [this issue](https://github.com/nodejs/node/issues/46347). I'm not sure why the types are breaking after I changed the line but I profiled the memory usage and it does appear to work correctly.